### PR TITLE
Add a frombeginning option to tail a file from the start of the file

### DIFF
--- a/tail.coffee
+++ b/tail.coffee
@@ -21,13 +21,17 @@ class Tail extends events.EventEmitter
           @buffer = parts.pop()
           @emit("line", chunk) for chunk in parts
 
-  constructor:(@filename, @separator='\n', @fsWatchOptions = {}) ->    
+  constructor:(@filename, @separator='\n', @frombeginning=false, @fsWatchOptions = {}) ->
     @buffer = ''
     @internalDispatcher = new events.EventEmitter()
     @queue = []
     @isWatching = false
     stats =  fs.statSync(@filename)
-    @pos = stats.size
+    if @frombeginning
+      @pos = 0
+      @watchEvent('change')
+    else
+      @pos = stats.size
     @internalDispatcher.on 'next',=>
       @readBlock()
     


### PR DESCRIPTION
This options allow to output the file from its beginning and not just changes since we started watching.
