### PR TITLE
Included example for the 'on error' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ tail = new Tail("fileToTail");
 tail.on("line", function(data) {
   console.log(data);
 });
+
+tail.on("error", function(error) {
+  console.log('ERROR: ', error);
+});
 ````
 
 Tail accepts the line separator as second parameter. If nothing is passed it is defaulted to new line '\n'.


### PR DESCRIPTION
Included example for the 'on error' event in the README.md file.  It's a bit more verbose, but it shows all the functionality.
