### PR TITLE
Allow users to ignore fs.watch "rename" events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ npm install tail
 ```
 
 #Use:
+
+##General:
 ```javascript
 Tail = require('tail').Tail;
 
@@ -21,6 +23,7 @@ tail.on("error", function(error) {
 });
 ````
 
+##Separator:
 Tail accepts the line separator as second parameter. If nothing is passed it is defaulted to new line '\n'.
 
 ```javascript
@@ -30,6 +33,15 @@ var lineSeparator= "-";
 new Tail("fileToTail",lineSeparator)
 ```
 
+##Options
+Tail allows further configuration with a third, optional object parameter. This parameter allows you to configure the underlying `fs.watch` / `fs.watchFile` methods and their behaviour.
+
+**Currently supported options:**
+- **persistent: true** (fs.watch, fs.watchFile) <br> indicates whether the process should continue to run as long as files are being watched
+- **ignoreRename: false** (fs.watch) <br> treats `rename` events as `change` events, rather than rewatching the file and resetting the watch position
+- **interval: 5007** (fs.watchFile) <br> indicates how often the target should be polled, in milliseconds
+
+##Events
 Tail emits two type of events:
 
 * line 

--- a/tail.coffee
+++ b/tail.coffee
@@ -42,7 +42,7 @@ class Tail extends events.EventEmitter
       fs.watchFile @filename, @fsWatchOptions, (curr, prev) => @watchFileEvent curr, prev
 
   watchEvent:  (e) ->
-    if e is 'change'
+    if e is 'change' or @fsWatchOptions.ignoreRename
       stats = fs.statSync(@filename)
       @pos = stats.size if stats.size < @pos #scenario where texts is not appended but it's actually a w+
       if stats.size > @pos


### PR DESCRIPTION
Hi,

I have a log file that I want to watch and which triggers "rename" events every now and then, without being actually renamed, truncated or deleted. If I do a normal `tail -f logfile`, I get the updates as expected. When using node-tail, however, the internal `fs.watch` treats some of the updates as `rename` events rather than `change` events. This might be a platform issue (I'm using Mac OSX) or an issue with the process that creates the logfile (I have no idea) - but when I force node-tail to use `fs.watchFile`, the problem goes away.
Since `rename` events reset the interal position and have a 1 second reload-delay, I'd like there to be a way to ignore these `rename` events and treat them as normal `change` events. Because `change` handles logfiles that are suddenly a lot shorter (ie. when actually renaming a file and replacing it with an empty one) perfectly fine, I don't see any harm in adding an option that allows the user to override the default behevaiour.
What do you think?
I also updated the docs to outline how these options could be used, along with the other options that were already there but not yet documented.

Cheers,
Steffen
