### PR TITLE
Add a frombeginning option to tail a file from the start of the file

### DIFF
--- a/tail.coffee
+++ b/tail.coffee
@@ -27,14 +27,13 @@ class Tail extends events.EventEmitter
     @queue = []
     @isWatching = false
     stats =  fs.statSync(@filename)
+    @internalDispatcher.on 'next',=>
+      @readBlock()
     if @frombeginning
       @pos = 0
       @watchEvent('change')
     else
       @pos = stats.size
-    @internalDispatcher.on 'next',=>
-      @readBlock()
-
     @watch()
 
 


### PR DESCRIPTION
From netantho fork, an option to read the file from the beginning.

I don't know if a pull request was already sent, but it seems interesting to include this feature in the main branch.

Best,
Adrien
