### PR TITLE
removed setting pos to 0 on unwatch

### DIFF
--- a/tail.coffee
+++ b/tail.coffee
@@ -60,7 +60,6 @@ class Tail extends events.EventEmitter
   unwatch: ->
     if fs.watch && @watcher
       @watcher.close()
-      @pos = 0
     else fs.unwatchFile @filename
     @isWatching = false
     @queue = []


### PR DESCRIPTION
I don't know if this is a wanted feature, but whenever i unwatch and watch again I get the whole file because of that, altough I never set frombeginning to true.