### PR TITLE
Emit an 'error' rather than throw an exception

### DIFF
--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -1,11 +1,11 @@
-events= require("events")
-fs =require('fs')
+events = require("events")
+fs = require('fs')
 
-environment = process.env['NODE_ENV'] || 'development'
+environment = process.env.NODE_ENV || 'development'
 
 class Tail extends events.EventEmitter
 
-  readBlock:()=>
+  readBlock: =>
     if @queue.length >= 1
       block = @queue.shift()
       if block.end > block.start
@@ -22,17 +22,41 @@ class Tail extends events.EventEmitter
           @buffer = parts.pop()
           @emit("line", chunk) for chunk in parts
 
-  constructor:(@filename, @separator=/[\r]{0,1}\n/, @fsWatchOptions = {}, @frombeginning=false) ->
+  constructor: (@filename, @separator=/[\r]{0,1}\n/, @fsWatchOptions = {}, @frombeginning=false) ->
     @buffer = ''
     @internalDispatcher = new events.EventEmitter()
     @queue = []
     @isWatching = false
-    stats =  fs.statSync(@filename)
-    @internalDispatcher.on 'next',=>
+    @stopWatching = false
+    @pos = 0
+    @internalDispatcher.on 'next', =>
       @readBlock()
-    @pos = if @frombeginning then 0 else stats.size
-    @watch()
 
+    @tryWatch()
+
+  tryWatch: ->
+    self = this
+
+    try
+      # Must be sync, otherwise we are not sure that we are missing some lines
+      stats = fs.statSync @filename
+      @pos = if @frombeginning then 0 else stats.size
+      @watch()
+
+      # If pos is not equal to stats.size, we have to trigger a watch event
+      if stats.size isnt @pos
+        @tryWatchEvent()
+    catch err
+      process.nextTick ->
+        self.emit 'error', err
+
+        # Since file did not exist, we want to read it from the beginning
+        self.frombeginning = true
+
+        # If 'unwatch' is called
+        if !self.stopWatching
+          # File does not exists, retry later
+          setTimeout self.tryWatch.bind(self), 500
 
   watch: ->
     return if @isWatching
@@ -41,30 +65,49 @@ class Tail extends events.EventEmitter
     else
       fs.watchFile @filename, @fsWatchOptions, (curr, prev) => @watchFileEvent curr, prev
 
-  watchEvent:  (e) ->
-    if e is 'change'
+  tryWatchEvent: ->
+    self = this
+
+    try
+      # Must be sync, otherwise we are not sure that we are missing some lines
       stats = fs.statSync(@filename)
       @pos = stats.size if stats.size < @pos #scenario where texts is not appended but it's actually a w+
       if stats.size > @pos
         @queue.push({start: @pos, end: stats.size})
         @pos = stats.size
         @internalDispatcher.emit("next") if @queue.length is 1
+    catch err
+      process.nextTick ->
+        self.emit 'error', err
+
+        # If 'unwatch' is called
+        if !self.stopWatching
+          # File does not exists, retry later
+          setTimeout self.tryWatchEvent.bind(self), 500
+
+  watchEvent: (e) ->
+    self = this
+
+    if e is 'change'
+      @tryWatchEvent()
     else if e is 'rename'
-      @unwatch()
-      setTimeout (=> @watch()), 1000
+      @clearWatch()
+      setTimeout (=> @tryWatch()), 500
 
   watchFileEvent: (curr, prev) ->
     if curr.size > prev.size
       @queue.push({start:prev.size, end:curr.size})
       @internalDispatcher.emit("next") if @queue.length is 1
 
-  unwatch: ->
+  clearWatch: ->
     if fs.watch && @watcher
       @watcher.close()
       @pos = 0
     else fs.unwatchFile @filename
     @isWatching = false
-    @queue = []
 
+  unwatch: ->
+    @clearWatch()
+    @stopWatching = true
 
 exports.Tail = Tail

--- a/test/tail.coffee
+++ b/test/tail.coffee
@@ -8,11 +8,12 @@ lineWindowsEnding = 'This is a windows line ending\r\n'
 lineLinuxEnding   = 'This is a linux line ending\n'
 
 describe 'Tail', ->
-  before (done) ->
-    fs.writeFile fileToTest, '', done
-
-  after (done) ->
-    fs.unlink fileToTest, done
+  afterEach (done) ->
+    fs.stat fileToTest, (err) ->
+      if err?
+        done()
+      else
+        fs.unlink fileToTest, done
 
   it 'should read a file with windows line ending', (done) ->
     nbOfLineToWrite = 100
@@ -23,7 +24,7 @@ describe 'Tail', ->
     tailedFile = new Tail fileToTest, null, {}
 
     tailedFile.on 'line', (line) ->
-      expect(line).to.be.equal lineWindowsEnding.replace(/[\r\n]/g, '')
+      expect(line).to.contain lineWindowsEnding.replace(/[\r\n]/g, '')
 
       ++nbOfReadLines
 
@@ -33,7 +34,7 @@ describe 'Tail', ->
         done()
 
     for index in [0..nbOfLineToWrite]
-      fs.writeSync fd, lineWindowsEnding
+      fs.writeSync fd, index + lineWindowsEnding
 
     fs.closeSync fd
 
@@ -46,7 +47,7 @@ describe 'Tail', ->
     tailedFile = new Tail fileToTest, null, {}
 
     tailedFile.on 'line', (line) ->
-      expect(line).to.be.equal lineLinuxEnding.replace(/[\r\n]/g, '')
+      expect(line).to.contain lineLinuxEnding.replace(/[\n]/g, '')
 
       ++nbOfReadLines
 
@@ -56,6 +57,70 @@ describe 'Tail', ->
         done()
 
     for index in [0..nbOfLineToWrite]
-      fs.writeSync fd, lineLinuxEnding
+      fs.writeSync fd, index + lineLinuxEnding
 
     fs.closeSync fd
+
+  it 'should send an error when we try to read a non-existing file', (done) ->
+    tailedFile = new Tail 'unknown file', null, {}
+    callbackOnce = false
+
+    tailedFile.on 'error', (err) ->
+      tailedFile.unwatch()
+      done()
+
+  it 'should send an error when we are reading a file that is being removed', (done) ->
+    @timeout 5000
+    nbOfLineToWrite = 100
+    nbOfReadLines   = 0
+
+    fd = fs.openSync fileToTest, 'w+'
+    tailedFile = new Tail fileToTest, null, {}
+
+    tailedFile.on 'error', (err) ->
+      if nbOfReadLines >= nbOfLineToWrite
+        tailedFile.unwatch()
+
+        done()
+
+    tailedFile.on 'line', (line) ->
+      expect(line).to.contain lineLinuxEnding.replace(/[\n]/g, '')
+
+      ++nbOfReadLines
+
+    for index in [0..nbOfLineToWrite]
+      fs.writeSync fd, index + lineLinuxEnding
+
+    fs.closeSync fd
+
+    setTimeout ->
+      fs.unlinkSync fileToTest
+    , 500
+
+  it 'should wait before reading a non-existing file', (done) ->
+    @timeout 5000
+    nbOfLineToWrite = 100
+    nbOfReadLines   = 0
+    writeFileOnce   = false
+
+    tailedFile = new Tail fileToTest, null, {}
+
+    tailedFile.on 'error', (err) ->
+      if !writeFileOnce
+        writeFileOnce = true
+        fd = fs.openSync fileToTest, 'w+'
+
+        for index in [0..nbOfLineToWrite]
+          fs.writeSync fd, index + lineLinuxEnding
+
+        fs.closeSync fd
+
+    tailedFile.on 'line', (line) ->
+      expect(line).to.contain lineLinuxEnding.replace(/[\n]/g, '')
+
+      ++nbOfReadLines
+
+      if (nbOfReadLines is nbOfLineToWrite)
+        tailedFile.unwatch()
+
+        done()


### PR DESCRIPTION
Since we are using EventEmitter, we should emit and error rather than throwing an exception.

TODO: If there is no listener for 'error' event, throw an exception