### PR TITLE
Fixes issue on Windows where fs.watch isn't properly supported.

### DIFF
--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -39,7 +39,7 @@ class Tail extends events.EventEmitter
     stats =  fs.statSync(@filename)
     @pos = if pos then pos else stats.size  
 
-    if fs.watch then @watcher = fs.watch @filename, @fsWatchOptions, (e) => @watchEvent e
+    if fs.watch and process.platform isnt 'win32' then @watcher = fs.watch @filename, @fsWatchOptions, (e) => @watchEvent e
     else
       fs.watchFile @filename, @fsWatchOptions, (curr, prev) => @watchFileEvent curr, prev
 


### PR DESCRIPTION
Fixes https://github.com/lucagrulla/node-tail/issues/11.

I tested the original script on Windows 8.1 and found that node-tail would not trigger a `line` event when Bunyan or Winston appended a line to the log.

This is due to flakey support if `fs.watch` on Windows. This fix makes Windows use `fs.watchFile`, which I believe reads the file for changes every 5007 milliseconds (by default). This is not as fast as using `fs.watch` but actually allows the tailer to work on Windows.