### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ new Tail(fileToTail)
 Optional parameters can be passed via a hash:
 
 ```javascript
-var options= {lineSeparator: /[\r]{0,1}\n/, fromBeginning: false, watchOptions: {}, follow: true, logger: console}
+var options= {separator: /[\r]{0,1}\n/, fromBeginning: false, watchOptions: {}, follow: true, logger: console}
 new Tail(fileToTail, options)
 ```
 
 # Available parameters:
 
-* `lineSeparator`:  the line separator token (default `/[\r]{0,1}\n/` to handle linux/mac (9+)/windows)
-* `watchOptions`:  the full set of options that can be passed to `fs.watch` as per node documentation (default: {})
+* `separator`:  the line separator token (default `/[\r]{0,1}\n/` to handle linux/mac (9+)/windows)
+* `fsWatchOptions`:  the full set of options that can be passed to `fs.watch` as per node documentation (default: {})
 * `fromBeginning`: forces the tail of the file from the very beginning of it instead of from the first new line that will be appended (default: `false`)
 * `follow`: simulate `tail -F` option. In the case the file is moved/renamed (or logrotated), if set to `true` `tail` will try to start tailing again after a 1 second delay, if set to `false` it will just emit an error event (default: `true`)
 * `logger`: a logger object(default: no logger). The passed logger has to respond to two methods:


### PR DESCRIPTION
fix misleading explanations.

There are some mismatches between document options and source code options when user initialize new Tail("fileToTail", options).

 :)
