### PR TITLE
Fix test that was incorrectly not waiting for callback

### DIFF
--- a/test/tail.coffee
+++ b/test/tail.coffee
@@ -17,7 +17,7 @@ describe 'Tail', ->
 
   lineEndings.forEach ({le, desc})->
     it 'should read a file with ' + desc + ' line ending', (done)->
-      text = 'This is a #{desc} line ending' + le
+      text = "This is a #{desc} line ending#{le}"
       nbOfLineToWrite = 100
       nbOfReadLines   = 0
 

--- a/test/tail.coffee
+++ b/test/tail.coffee
@@ -16,14 +16,14 @@ describe 'Tail', ->
   lineEndings = [{le:'\r\n', desc: "Windows"}, {le:'\n', desc: "Linux"}]
 
   lineEndings.forEach ({le, desc})->
-    it 'should read a file with ' + desc + ' line ending', ()->
-      text = 'This is a #{desc} line ending#{le}'
+    it 'should read a file with ' + desc + ' line ending', (done)->
+      text = 'This is a #{desc} line ending' + le
       nbOfLineToWrite = 100
       nbOfReadLines   = 0
 
       fd = fs.openSync fileToTest, 'w+'
 
-      tailedFile = new Tail fileToTest, {fsWatchOptions: {interval:100}, logger: console, encoding: "utf-16"}
+      tailedFile = new Tail fileToTest, {fsWatchOptions: {interval:100}, logger: console}
 
       tailedFile.on 'line', (line) ->
         expect(line).to.be.equal text.replace(/[\r\n]/g, '')


### PR DESCRIPTION
The line ending tests did not have `done` set in the test definition and therefore were not waiting for `line` event and were incorrectly passing. Once I fixed this the tests failed, firstly because `encoding: "utf-16"` caused `Unknown encoding: utf-16`, perhaps this is a machine dependent issue. If you know how to fix it I can commit a change. For now I've removed the encoding option. 
After that the next issue is that CoffeeScript string interpolation does not work on single quote strings, I've fixed this too.