### PR TITLE
Add error handling when file is deleted while watching

### DIFF
--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -43,7 +43,12 @@ class Tail extends events.EventEmitter
   watch: (pos) ->
     return if @isWatching
     @isWatching = true
-    stats =  fs.statSync(@filename)
+    try
+      stats =  fs.statSync(@filename)
+    catch err
+      @logger.error("watch for #{@filename} failed: #{@err}") if @logger
+      @emit("error", "watch for #{@filename} failed: #{@err}")
+      return
     @pos = if pos? then pos else stats.size  
 
     if @logger
@@ -59,7 +64,12 @@ class Tail extends events.EventEmitter
 
   watchEvent: (e) ->
     if e is 'change'
-      stats = fs.statSync(@filename)
+      try
+        stats = fs.statSync(@filename)
+      catch err
+        @logger.error("'change' event for #{@filename}. #{@err}") if @logger
+        @emit("error", "'change' event for #{@filename}. #{@err}")
+        return
       @pos = stats.size if stats.size < @pos #scenario where texts is not appended but it's actually a w+
       if stats.size > @pos
         @queue.push({start: @pos, end: stats.size})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers mocha --compilers coffee:coffee-script/register
+--compilers mocha --compilers coffee:coffee-script/register --timeout 3000

--- a/test/tail.coffee
+++ b/test/tail.coffee
@@ -61,3 +61,24 @@ describe 'Tail', ->
       fs.writeSync fd, l+'\n'
 
     fs.closeSync fd
+
+  it 'should send error event on deletion of file while watching', (done)->
+    text = "This is a line\n"
+
+    fd = fs.openSync fileToTest, 'w+'
+
+    tailedFile = new Tail fileToTest, {fsWatchOptions: {interval:100}, logger: console}
+
+    # ensure error gets called when the file is deleted
+    tailedFile.on 'error', (line) ->
+      # recreate file so that `afterEach` can cleanup
+      fd = fs.openSync fileToTest, 'w+'
+      done()
+
+    tailedFile.on 'line', (line) ->
+      # delete the file
+      fs.unlinkSync fileToTest
+
+    fs.writeSync fd, text
+
+    fs.closeSync fd


### PR DESCRIPTION
This is a fix for [#54](https://github.com/lucagrulla/node-tail/issues/54). This issue occurs when the file is deleted while watching it. This will now emit an 'error' event and no longer crash.

I've added a test for this, however it takes slightly over two seconds to actually crash, so I've increased mocha's timeout to three seconds. I've followed the other tests and used real files to test, so it's understandable that this can take time to run. However, if there's a better way to do this, let me know.