### PR TITLE
Build the package on installation as well as before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "engines": {
     "node": ">= 0.4.0"
   },
+  "scripts": {
+    "build": "cake build",
+    "prepare": "npm run build"
+  },
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "scripts": {
     "build": "cake build",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run test",
+    "test": "mocha"
   },
   "license": "MIT",
   "dependencies": {},


### PR DESCRIPTION
I would guess that you were manually executing the Cakefile before? Anyhow adding these build scripts is nice because it lets the package be installed from a Git URL, in which case the package will need to be built on installation.