### PR TITLE
Update @pos in watchFileEvent to enable user to wait until entire log is processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,46 @@ To start watching again:
 tail.watch()
 ```
 
+## Determining if an entire file has been processed
+This example (in Typescript) shows how to wait for Tail to fully process a log file. 
+```typescript
+    // execResult is a Q.Promise<number> that wraps an execution of an asynchronous tool creating a large logfile
+
+    var logTail = new tail.Tail(logfile, { fromBeginning: true, follow: true, logger: console, useWatchFile: true,
+            fsWatchOptions: { interval: 1009 } });
+
+    logTail.on("line", function(data) {
+        console.log(data);
+    });
+
+    logTail.on("error", function(error) {
+        console.log('ERROR: ', error);
+    });
+
+    // Wait for async task to finish
+    var result = await execResult;
+    // Get final size of log file
+    var size = fs.statSync(logfile).size;
+
+    // Wait for tail to finish
+    do {
+        console.log('Waiting for tail to finish...');
+        await sleep(2089);
+    } while (size > getTailPos(logTail) || getTailQueueLength(logTail) > 0);
+
+    logTail.unwatch();
+```
+This uses two accessors to obtain the pos and queue length from the tail object.
+```typescript
+function getTailPos(t:any) : number {
+    return t.pos;
+}
+
+function getTailQueueLength(t:any) : number {
+    return t.queue.length;
+}
+```
+
 # Configuration
 The only mandatory parameter is the path to the file to tail. 
 

--- a/README.md
+++ b/README.md
@@ -41,46 +41,6 @@ To start watching again:
 tail.watch()
 ```
 
-## Determining if an entire file has been processed
-This example (in Typescript) shows how to wait for Tail to fully process a log file. 
-```typescript
-    // execResult is a Q.Promise<number> that wraps an execution of an asynchronous tool creating a large logfile
-
-    var logTail = new tail.Tail(logfile, { fromBeginning: true, follow: true, logger: console, useWatchFile: true,
-            fsWatchOptions: { interval: 1009 } });
-
-    logTail.on("line", function(data) {
-        console.log(data);
-    });
-
-    logTail.on("error", function(error) {
-        console.log('ERROR: ', error);
-    });
-
-    // Wait for async task to finish
-    var result = await execResult;
-    // Get final size of log file
-    var size = fs.statSync(logfile).size;
-
-    // Wait for tail to finish
-    do {
-        console.log('Waiting for tail to finish...');
-        await sleep(2089);
-    } while (size > getTailPos(logTail) || getTailQueueLength(logTail) > 0);
-
-    logTail.unwatch();
-```
-This uses two accessors to obtain the pos and queue length from the tail object.
-```typescript
-function getTailPos(t:any) : number {
-    return t.pos;
-}
-
-function getTailQueueLength(t:any) : number {
-    return t.queue.length;
-}
-```
-
 # Configuration
 The only mandatory parameter is the path to the file to tail. 
 

--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -100,6 +100,7 @@ class Tail extends events.EventEmitter
 
   watchFileEvent: (curr, prev) ->
     if curr.size > prev.size
+      @pos = curr.size    # Update @pos so that a consumer can determine if entire file has been handled
       @queue.push({start:prev.size, end:curr.size})
       @internalDispatcher.emit("next") if @queue.length is 1
 


### PR DESCRIPTION
I ran into this while writing a custom build task for Visual Studio Team Services. The task runs a Unity 3D build. Unity sends all of its output to a logfile instead of stdout.

I found that using the default mode of node-tail (fs.watch) it would process a small amount at the start of the file and then nothing until the Unity build finished. This meant that the build agent was unable to stream the logfile until after the Unity build completed. This is running under node.js on a Windows VM.

The watchEvent method updates @pos as each block is queued. By inspecting @pos and @queue.length I was able to wait for the entire log file to be streamed--but only after Unity had finished and closed the log file.

Changing the useWatchFile option to true allowed the log to be streamed, but it was typically not able to finish (log write speed faster than tailing it). Inspecting just the @queue.length did not suffice.

Therefore, I added the code to update @pos to the watchFileEvent.

I also added the scenario to the README.
