### PR TITLE
Add flushAtEOF flag to send last buffer on close of input

### DIFF
--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -15,6 +15,9 @@ class Tail extends events.EventEmitter
         stream.on 'end',=>
           x = @queue.shift()
           @internalDispatcher.emit("next") if @queue.length > 0
+          if @flushAtEOF
+            @emit("line", @buffer)
+            @buffer = ''
         stream.on 'data', (data) =>
           @buffer += data
 
@@ -26,7 +29,7 @@ class Tail extends events.EventEmitter
     super filename, options
     @filename = filename
     {@separator = /[\r]{0,1}\n/,  @fsWatchOptions = {}, @fromBeginning = false,
-    @follow = true, @logger, @useWatchFile = false, @encoding = "utf-8"} = options
+    @follow = true, @logger, @useWatchFile = false, @flushAtEOF = false, @encoding = "utf-8"} = options
 
     if @logger
       @logger.info("Tail starting...")

--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -15,7 +15,7 @@ class Tail extends events.EventEmitter
         stream.on 'end',=>
           x = @queue.shift()
           @internalDispatcher.emit("next") if @queue.length > 0
-          if @flushAtEOF
+          if @flushAtEOF && @buffer.length > 0
             @emit("line", @buffer)
             @buffer = ''
         stream.on 'data', (data) =>

--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -19,11 +19,13 @@ class Tail extends events.EventEmitter
             @emit("line", @buffer)
             @buffer = ''
         stream.on 'data', (data) =>
-          @buffer += data
-
-          parts = @buffer.split(@separator)
-          @buffer = parts.pop()
-          @emit("line", chunk) for chunk in parts
+          if @separator is null
+            @emit("line", data)
+          else
+            @buffer += data
+            parts = @buffer.split(@separator)
+            @buffer = parts.pop()
+            @emit("line", chunk) for chunk in parts
 
   constructor:(filename, options = {}) ->
     super filename, options


### PR DESCRIPTION
As per discussion of #75  - pull request to add an extra option - flushAtEOF. When set true will emit any remaining contents of the buffer when the input stream closes - e.g. the last line of a file that doesn't end with the split character.

Second change allows separator of null to not try to split the incoming chunk and pass it on as - is - this will help with binary files - eg images being overwritten into a common file.

Should also help fix #18