### PR TITLE
Remove undefined variable 'e'

### DIFF
--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -52,8 +52,8 @@ class Tail extends events.EventEmitter
       try
         stats = fs.statSync(filename)
       catch err
-        @logger.error("'#{e}' event for #{filename}. #{err}") if @logger
-        @emit("error", "'#{e}' event for #{filename}. #{err}")
+        @logger.error("change event for #{filename} failed: #{err}") if @logger
+        @emit("error", "change event for #{filename} failed: #{err}")
         return
       @pos = stats.size if stats.size < @pos #scenario where texts is not appended but it's actually a w+
       if stats.size > @pos


### PR DESCRIPTION
When the line `stats = fs.statSync(filename)` fails, an error message is supposed to be thrown. However, the error message attempts to use the undefined variable 'e'. 

I've tweaked the line to not use the undefined variable.