### PR TITLE
Emit position of actual file size when watching

### DIFF
--- a/src/tail.coffee
+++ b/src/tail.coffee
@@ -84,6 +84,7 @@ class Tail extends events.EventEmitter
       @emit("error", "watch for #{@filename} failed: #{err}")
       return
     @pos = if fromBeginning then 0 else stats.size
+    @emit("watch", @pos)
     
     if @pos == 0
       @change(@filename)


### PR DESCRIPTION
When starting to read a file from a specific position, I needed to know where to display a button to the user to load the start of the file, but I used a second fs.stat which led to some weird behaviours if the file is being written rapidly.

To counter that, I created an event, *watch*, which is emitted when the file is being read at a specific position (in the watch function), so I could use that number later to retrieve the start of the file.

I didn't find another idea for the name, be pleased to rename it if necessary.

Thanks in advance