### PR TITLE
Allow setting `follow` to `false`.

### DIFF
--- a/src/tail.js
+++ b/src/tail.js
@@ -17,7 +17,7 @@ class Tail extends events.EventEmitter {
         this.absPath = path.dirname(this.filename);
         this.separator = (options.separator !== undefined) ? options.separator : /[\r]{0,1}\n/;// null is a valid param
         this.fsWatchOptions = options.fsWatchOptions || {};
-        this.follow = options.follow || true;
+        this.follow = 'follow' in options ? options.follow : true;
         this.logger = options.logger || new devNull();
         this.useWatchFile = options.useWatchFile || false;
         this.flushAtEOF = options.flushAtEOF || false;


### PR DESCRIPTION
The `|| true` meant this was always being set to true.

Just if of use :-) (No stress at all if you want to implement this in a different way, just figured might as well create a pr rather than just an issue :-) )

(Was just trying with `new Tail("fileToTail", { follow: false })`, for context)