### PR TITLE
Add try/catch to watchEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "file",
     "logs"
   ],
-  "version": "2.2.3",
+  "version": "2.2.4",
   "homepage": "https://www.lucagrulla.com/node-tail",
   "repository": {
     "type": "git",

--- a/src/tail.js
+++ b/src/tail.js
@@ -184,10 +184,15 @@ class Tail extends events.EventEmitter {
     }
 
     watchEvent(e, evtFilename) {
-        if (e === 'change') {
-            this.change();
-        } else if (e === 'rename') {
-            this.rename(evtFilename);
+        try {
+            if (e === 'change') {
+                this.change();
+            } else if (e === 'rename') {
+                this.rename(evtFilename);
+            }
+        } catch (err) {
+            this.logger.error(`watchEvent for ${this.filename} failed: ${err}`);
+            this.emit("error", `watchEvent for ${this.filename} failed: ${err}`);
         }
     }
 


### PR DESCRIPTION
The watchEvent method is an event handler for fs.watch().

It has no try/catch handler around it.  When change() throws due to a ENOENT there is nothing to catch the exception which causes the process to terminate.

Added a try/catch around watchEvent and both log and emit any errors that are raised.

#143 