### PR TITLE
fixes issue where empty files with nLines options would hang forever

### DIFF
--- a/src/tail.js
+++ b/src/tail.js
@@ -143,6 +143,10 @@ class Tail extends events.EventEmitter {
         const { size } = fs.statSync(this.filename);
         const fd = fs.openSync(this.filename, 'r');
 
+        if (size === 0) {
+            return 0;
+        }
+
         // Start from the end of the file and work backwards in specific chunks
         let currentReadPosition = size;
         const chunkSizeBytes = Math.min(1024, size);

--- a/test/test.js
+++ b/test/test.js
@@ -230,6 +230,13 @@ describe('Tail', function () {
     });
 
     describe('nLines', () => {
+        it(`should gracefully handle an empty file`, function (done) {
+            const n = 3;
+            const tailedFile = new Tail(fileToTest, { nLines: n, flushAtEOF: true, fsWatchOptions: { interval: 100 } });
+            tailedFile.unwatch();
+            done();
+        });
+
         lineEndings.forEach(({ le, desc }) => {
             it(`should respect nLines when a file with ${desc} line endings ends with a newline`, function (done) {
                 const fd = fs.openSync(fileToTest, 'w+');
@@ -250,7 +257,7 @@ describe('Tail', function () {
                     }
                     counter++;
                 })
-            })
+            });
 
             it(`should respect nLines when afile with ${desc} line endings does not end with newline`, function (done) {
                 const fd = fs.openSync(fileToTest, 'w+');


### PR DESCRIPTION
Fixes issue from https://github.com/lucagrulla/node-tail/pull/162

I didn't include a base case in the new `nLines` logic causing an infinite loop on empty files. This PR fixes this and adds a test case.

Apologies for this! I should have tested for this earlier.