### PR TITLE
Guard against potential file changing underneath the watcher causing downstream line corruption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tail",
-  "version": "2.2.4",
+  "version": "2.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tail",
-      "version": "2.2.4",
+      "version": "2.2.6",
       "license": "MIT",
       "devDependencies": {
         "chai": "4.x",

--- a/package.json
+++ b/package.json
@@ -20,13 +20,11 @@
     "type": "git",
     "url": "git://github.com/lucagrulla/node-tail.git"
   },
-  "main": "lib/tail",
+  "main": "src/tail",
   "engines": {
     "node": ">= 6.0.0"
   },
   "scripts": {
-    "build": "rm -f ./lib/** && cp src/tail.js ./lib/",
-    "prepare": "npm run build",
     "prepublishOnly": "npm run test",
     "test": "mocha",
     "coverage": "nyc npm run test"

--- a/src/tail.js
+++ b/src/tail.js
@@ -210,6 +210,19 @@ class Tail extends events.EventEmitter {
             const block = this.queue[0];
             if (block.end > block.start) {
                 let stream = fs.createReadStream(this.filename, { start: block.start, end: block.end - 1, encoding: this.encoding });
+
+                // If this.buffer has a partial line carried over from the previous block,
+                // its start offset is block.start minus those buffered bytes.
+                let lineStartOffset = block.start - Buffer.byteLength(this.buffer);
+
+                // Build a capturing-group version of the separator so we can measure
+                // exact separator byte lengths and advance lineStartOffset accurately.
+                const capturingSep = this.separator instanceof RegExp
+                  ? new RegExp(`(${this.separator.source})`, this.separator.flags.replace('g', ''))
+                  : this.separator !== null
+                    ? new RegExp(`(${this.separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`)
+                    : null;
+
                 stream.on('error', (error) => {
                     this.logger.error(`Tail error: ${error}`);
                     this.emit('error', error);
@@ -220,19 +233,30 @@ class Tail extends events.EventEmitter {
                         this.internalDispatcher.emit('next');
                     }
                     if (this.flushAtEOF && this.buffer.length > 0) {
-                        this.emit('line', this.buffer);
+                        const startOffset = lineStartOffset;
+                        const endOffset = startOffset + Buffer.byteLength(this.buffer);
+                        this.emit('line', this.buffer, { startOffset, endOffset });
                         this.buffer = "";
                     }
                 });
                 stream.on('data', (d) => {
                     if (this.separator === null) {
-                        this.emit("line", d);
+                        const startOffset = lineStartOffset;
+                        const endOffset = startOffset + Buffer.byteLength(d);
+                        lineStartOffset = endOffset;
+                        this.emit('line', d, { startOffset, endOffset });
                     } else {
                         this.buffer += d;
-                        let parts = this.buffer.split(this.separator);
-                        this.buffer = parts.pop();
-                        for (const chunk of parts) {
-                            this.emit("line", chunk);
+                        const rawParts = this.buffer.split(capturingSep);
+                        this.buffer = rawParts[rawParts.length - 1];
+                        for (let i = 0; i < rawParts.length - 1; i += 2) {
+                            const chunk = rawParts[i];
+                            const sep = rawParts[i + 1];
+
+                            const startOffset = lineStartOffset;
+                            const endOffset = startOffset + Buffer.byteLength(chunk);
+                            this.emit('line', chunk, { startOffset, endOffset });
+                            lineStartOffset = endOffset + Buffer.byteLength(sep);
                         }
                     }
                 });

--- a/src/tail.js
+++ b/src/tail.js
@@ -42,6 +42,11 @@ class Tail extends events.EventEmitter {
         this.queue = [];
         this.isWatching = false;
         this.pos = 0;
+        this.activeStream = null;
+        // Incremented whenever we reset on shrink/truncation. Each read stream captures
+        // the current generation so stale async callbacks from the pre-reset file state
+        // can be ignored instead of mutating buffer/queue with old bytes.
+        this.readGeneration = 0;
 
         // this.internalDispatcher.on('next',this.readBlock);
         this.internalDispatcher.on('next', () => {
@@ -205,15 +210,37 @@ class Tail extends events.EventEmitter {
         }
     }
 
+    resetState(cursorPosition) {
+        // Once the file size moves backward, any carried partial buffer and queued
+        // reads are no longer trustworthy. Drop them so stale bytes cannot be
+        // prepended to freshly written content after truncation or rewrite.
+        this.logger.info(`Resetting tail state for ${this.filename} at cursor ${cursorPosition}`);
+        this.buffer = '';
+        this.queue = [];
+        this.currentCursorPos = cursorPosition;
+        // Invalidate any in-flight readBlock() streams. They may still emit 'data'/'end'
+        // after we destroy them, so their handlers must be able to detect they belong to
+        // the old file state and ignore those callbacks.
+        this.readGeneration++;
+        if (this.activeStream) {
+            this.activeStream.destroy();
+            this.activeStream = null;
+        }
+    }
+
     readBlock() {
         if (this.queue.length >= 1) {
             const block = this.queue[0];
             if (block.end > block.start) {
+                // Snapshot the file-state epoch for this stream. If resetState() runs while
+                // this read is in flight, later callbacks from this stream must be ignored.
+                const readGeneration = this.readGeneration;
                 let stream = fs.createReadStream(this.filename, { start: block.start, end: block.end - 1, encoding: this.encoding });
+                this.activeStream = stream;
 
                 // If this.buffer has a partial line carried over from the previous block,
                 // its start offset is block.start minus those buffered bytes.
-                let lineStartOffset = block.start - Buffer.byteLength(this.buffer);
+                let lineStartOffset = Math.max(0, block.start - Buffer.byteLength(this.buffer));
 
                 // Build a capturing-group version of the separator so we can measure
                 // exact separator byte lengths and advance lineStartOffset accurately.
@@ -223,11 +250,33 @@ class Tail extends events.EventEmitter {
                     ? new RegExp(`(${this.separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`)
                     : null;
 
+                const clearActiveStream = () => {
+                    if (this.activeStream === stream) {
+                        this.activeStream = null;
+                    }
+                };
+
                 stream.on('error', (error) => {
+                    clearActiveStream();
+                    // resetState() destroys the stale stream on purpose; do not surface that
+                    // expected teardown as a real tail error.
+                    if (readGeneration !== this.readGeneration && error && error.code === 'ERR_STREAM_DESTROYED') {
+                        return;
+                    }
                     this.logger.error(`Tail error: ${error}`);
                     this.emit('error', error);
                 });
+                stream.on('close', () => {
+                    clearActiveStream();
+                });
                 stream.on('end', () => {
+                    clearActiveStream();
+                    // A stale stream can still finish after resetState(). Its queue/buffer
+                    // bookkeeping belongs to the previous file state and must not run now.
+                    if (readGeneration !== this.readGeneration) {
+                        return;
+                    }
+
                     let _ = this.queue.shift();
                     if (this.queue.length > 0) {
                         this.internalDispatcher.emit('next');
@@ -240,6 +289,11 @@ class Tail extends events.EventEmitter {
                     }
                 });
                 stream.on('data', (d) => {
+                    // Ignore bytes from any stream that started before the most recent reset.
+                    if (readGeneration !== this.readGeneration) {
+                        return;
+                    }
+
                     if (this.separator === null) {
                         const startOffset = lineStartOffset;
                         const endOffset = startOffset + Buffer.byteLength(d);
@@ -267,7 +321,7 @@ class Tail extends events.EventEmitter {
     change() {
         let p = this.latestPosition()
         if (p < this.currentCursorPos) {//scenario where text is not appended but it's actually a w+
-            this.currentCursorPos = p
+            this.resetState(p)
         } else if (p > this.currentCursorPos) {
             this.queue.push({ start: this.currentCursorPos, end: p });
             this.currentCursorPos = p
@@ -340,9 +394,12 @@ class Tail extends events.EventEmitter {
     }
 
     watchFileEvent(curr, prev) {
-        if (curr.size > prev.size) {
+        if (curr.size < prev.size || curr.size < this.currentCursorPos) {
+            this.resetState(curr.size);
+        } else if (curr.size > this.currentCursorPos) {
+            const start = this.currentCursorPos;
             this.currentCursorPos = curr.size;    //Update this.currentCursorPos so that a consumer can determine if entire file has been handled
-            this.queue.push({ start: prev.size, end: curr.size });
+            this.queue.push({ start, end: curr.size });
             if (this.queue.length == 1) {
                 this.internalDispatcher.emit("next");
             }

--- a/test/test.js
+++ b/test/test.js
@@ -304,4 +304,74 @@ describe('Tail', function () {
         fs.unlinkSync(fileToTest);
     }, 2000);
 });
+
+    describe('truncate/reset handling', () => {
+        const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+        it('should discard buffered partial content after shrink via change()', async function () {
+            this.timeout(5000);
+            const tailedFile = new Tail(fileToTest, { fromBeginning: true, fsWatchOptions: { interval: 100 } });
+            const lines = [];
+
+            tailedFile.on('line', function (line, offsets) {
+                lines.push({ line, offsets });
+            });
+
+            fs.appendFileSync(fileToTest, 'Player-10');
+            tailedFile.change();
+            await wait(50);
+
+            fs.truncateSync(fileToTest, 0);
+            tailedFile.change();
+            await wait(50);
+
+            const nextLine = '3/24/2026 06:17:45.7751 SPELL_DAMAGE';
+            fs.appendFileSync(fileToTest, `${nextLine}\n`);
+            tailedFile.change();
+            await wait(100);
+
+            tailedFile.unwatch();
+
+            expect(lines).to.deep.equal([
+                {
+                    line: nextLine,
+                    offsets: { startOffset: 0, endOffset: Buffer.byteLength(nextLine) }
+                }
+            ]);
+        });
+
+        it('should discard buffered partial content after shrink via watchFileEvent()', async function () {
+            this.timeout(5000);
+            const tailedFile = new Tail(fileToTest, { fromBeginning: true, useWatchFile: true, fsWatchOptions: { interval: 100 } });
+            const lines = [];
+            fs.unwatchFile(fileToTest);
+
+            tailedFile.on('line', function (line, offsets) {
+                lines.push({ line, offsets });
+            });
+
+            fs.appendFileSync(fileToTest, 'Player-10');
+            tailedFile.watchFileEvent({ size: 9 }, { size: 0 });
+            await wait(100);
+
+            fs.truncateSync(fileToTest, 0);
+            tailedFile.watchFileEvent({ size: 0 }, { size: 9 });
+            await wait(100);
+
+            const nextLine = '3/24/2026 06:17:45.7751 SPELL_DAMAGE';
+            fs.appendFileSync(fileToTest, `${nextLine}\n`);
+            tailedFile.watchFileEvent({ size: Buffer.byteLength(`${nextLine}\n`) }, { size: 0 });
+            await wait(200);
+
+            tailedFile.unwatch();
+
+            expect(lines).to.deep.equal([
+                {
+                    line: nextLine,
+                    offsets: { startOffset: 0, endOffset: Buffer.byteLength(nextLine) }
+                }
+            ]);
+        });
+
+    });
 });


### PR DESCRIPTION
We had seen some issues where malformed lines came through the watcher, and narrowed it down to this, where a change to the file while tailing could allow part of the buffer to contain data from before the file change, and the remaining part of the buffer to have data from after the file change. It would then stick those two together and send them down the pipe, causing malformed content to be sent to the listener.